### PR TITLE
fix: zmk-specific board name

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -18,9 +18,9 @@
 #
 ---
 include:
-  - board: nice_nano@2.0.0
+  - board: nice_nano@2.0.0//zmk
     shield: corne_left
-  - board: nice_nano@2.0.0
+  - board: nice_nano@2.0.0//zmk
     shield: corne_right
-  - board: nice_nano@2.0.0
+  - board: nice_nano@2.0.0//zmk
     shield: settings_reset


### PR DESCRIPTION
CI pipeline stopped working due to updates in zmk build pipeline
See zmk PR:
https://github.com/zmkfirmware/zmk/pull/3265